### PR TITLE
Fix the command path issue

### DIFF
--- a/src/Console/Commands/CustomMigrateCommand.php
+++ b/src/Console/Commands/CustomMigrateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sayeed\CustomMigrate\Commands;
+namespace Sayeed\CustomMigrate\console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;

--- a/src/CustomMigrateServiceProvider.php
+++ b/src/CustomMigrateServiceProvider.php
@@ -24,7 +24,7 @@ class CustomMigrateServiceProvider extends ServiceProvider
     public function register()
     {
         $this->commands([
-            \Sayeed\CustomMigrate\Commands\CustomMigrateCommand::class,
+            \Sayeed\CustomMigrate\Console\Commands\CustomMigrateCommand::class,
         ]);
     }
 }


### PR DESCRIPTION
When I ran the command of installing the package the ` Target class [Sayeed\CustomMigrate\Commands\CustomMigrateCommand] does not exist.` error was triggered and when I changed the path where this PR makes, the problem was solved